### PR TITLE
Let toolbox elements reflow after window resize.

### DIFF
--- a/src/core-ui/highed.toolbox.js
+++ b/src/core-ui/highed.toolbox.js
@@ -216,6 +216,13 @@ highed.Toolbox = function(parent, attr) {
     highed.dom.on(icon, 'click', toggle);
     highed.dom.ap(bar, icon);
     highed.dom.ap(contents, highed.dom.ap(title, helpIcon), userContents);
+    highed.dom.on(window, 'resize', function () {
+      highed.dom.style(body, { height: '' });
+      if (expanded) {
+        var height = resizeBody().h;
+        entryEvents.emit('Expanded', highed.dom.size(bar), height - 20);
+      }
+    });
 
     exports = {
       on: entryEvents.on,


### PR DESCRIPTION
Not sure about firing the `Expanded` event, it is not semantically correct but it moves the stuff to the right place.