### PR TITLE
Changing template now overwrites customizedOptions

### DIFF
--- a/src/ui/highed.chartpreview.js
+++ b/src/ui/highed.chartpreview.js
@@ -517,7 +517,7 @@ highed.ChartPreview = function(parent, attributes) {
     constr = template.constructor || 'Chart';
 
     highed.clearObj(templateOptions);
-
+    
     if (customizedOptions.xAxis) {
       delete customizedOptions.xAxis;
     }
@@ -530,6 +530,11 @@ highed.ChartPreview = function(parent, attributes) {
 
     gc(function(chart) {
       templateOptions = highed.merge({}, template.config || {});
+
+      highed.merge(
+        customizedOptions,
+        highed.merge(templateOptions)
+      );
 
       updateAggregated();
       init(aggregatedOptions);


### PR DESCRIPTION
Template options would get overwritten when merging with customizedOptions at line 414. Ive just overwritten the customized options with the new template options before it gets to that step